### PR TITLE
Update Drupal Extension to 3.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "drupal/drupal-extension": "~3.2.0",
+        "drupal/drupal-extension": "~3.3.0",
         "behat/mink": "~1.7",
         "behat/mink-goutte-driver": "~1.2",
         "jcalderonzumba/gastonjs": "~1.0.2",


### PR DESCRIPTION
Port of acquia/lightning#460.

The tests are failing, as expected, since they can only pass with Panels and Panelizer patches that are merged into Lightning HEAD, but not in a tagged release yet.