### PR TITLE
Ignore libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Ignore non-custom parts of Drupal.
 /docroot/core
+/docroot/libraries
 /docroot/modules/contrib
 /docroot/profiles/contrib
 /docroot/themes/contrib


### PR DESCRIPTION
Now that composer is installing libraries, they should not be committed to source repos.