### PR TITLE
Remove dependency on Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "symfony/css-selector": "~2.8",
         "behat/behat": "^3.0",
         "se/selenium-server-standalone": "^2.53",
-        "composer/composer": "^1.3",
         "drush/drush": "^9.0",
         "drupal/console": "1.0.1",
         "drupal/media_entity_generic": "^1.0",


### PR DESCRIPTION
composer/composer has a dev dependency on justinrainbow/json-schema which causes problems with Lightning API/metatag. Ultimately, those problems need to be addressed. But we shouldn't block testing Lightning Project on something that isn't a dependency of it.