### PR TITLE
Update to Lightning 3.2 / core 8.6 and add quick start command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
 
   # Update codebase to head.
   - composer nuke
-  - composer require acquia/lightning:dev-8.6.x-prerelease --no-update
+  - composer require acquia/lightning:dev-8.x-3.x --no-update
   - composer update
   # Regenerate Behat configuration, in case testing set-up has changed in HEAD.
   - lightning configure:behat $HOST

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
 
   # Update codebase to head.
   - composer nuke
-  - composer require acquia/lightning:dev-8.x-3.x --no-update
+  - composer require acquia/lightning:dev-8.6.x-prerelease --no-update
   - composer update
   # Regenerate Behat configuration, in case testing set-up has changed in HEAD.
   - lightning configure:behat $HOST

--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
 This is a Composer-based installer for the [Lightning](https://www.drupal.org/project/lightning) Drupal distribution. Welcome to the future!
 
 ## Get Started
+
 ```
 $ composer create-project acquia/lightning-project MY_PROJECT
+$ cd MY_PROJECT && composer quick-start
 ```
-Composer will create a new directory called MY_PROJECT containing a `docroot` directory with a full Lightning code base therein. You can then install it like you would any other Drupal site.
 
-Normally, Composer will install all dependencies into a `vendor` directory that is *next* to `docroot`, not inside it. This may create problems in certain hosting environments, so if you need to, you can tell Composer to install dependencies into `docroot/vendor` instead:
+This will create a functioning Lightning site, open a web browser, and log you
+into the site using Drupal's built-in Quick Start command. If you'd rather use
+your own database and web server, you can skip the second step above and install
+Lightning like you would any other Drupal site.
+
+Normally, Composer will install all dependencies into a `vendor` directory that
+is *next* to `docroot`, not inside it. This may create problems in certain
+hosting environments, so if you need to, you can tell Composer to install
+dependencies into `docroot/vendor` instead:
+
 ```
 $ composer create-project acquia/lightning-project MY_PROJECT --no-install
 $ composer config vendor-dir docroot/vendor
 $ cd MY_PROJECT
 $ composer install
 ```
+
 Either way, remember to keep the `composer.json` and `composer.lock` files that exist above `docroot` -- they are controlling your dependencies.
 
 ## Maintenance

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.6.0",
-        "acquia/lightning": "~3.1.0"
+        "acquia/lightning": "~3.2.0"
     },
     "repositories": {
         "drupal": {
@@ -31,9 +31,13 @@
         }
     },
     "scripts": {
-      "post-install-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
-      "post-update-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
-      "nuke": "rm -r -f docroot/modules/contrib docroot/profiles/contrib/lightning vendor composer.lock"
+        "post-install-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+        "post-update-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+        "nuke": "rm -r -f docroot/modules/contrib docroot/profiles/contrib/lightning vendor composer.lock",
+        "quick-start": [
+            "composer install",
+            "php docroot/core/scripts/drupal quick-start lightning --no-interaction"
+        ]
     },
     "extra": {
         "installer-types": [

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
             "no-api": true
         }
     },
+    "config": {
+        "process-timeout": 0
+    },
     "scripts": {
         "post-install-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "post-update-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",


### PR DESCRIPTION
**Do not merge**

We can merge this once we merge 8.6.0-prerelease into the 8.x-3.x branch in Lightning. (Post release of 8.6.0)

Before merge, we should revert travis.yml back to it's previous state which pulled in the main 8.x-3.x branch of Lightning