### PR TITLE
Enables exiting when patches fail to apply.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
                 "type:drupal-drush"
             ]
         },
-        "enable-patching": true
+        "enable-patching": true,
+        "composer-exit-on-patch-failure": true
     }
 }


### PR DESCRIPTION
Currently patches just get skipped if they fail to apply. Since Lightning doesn't pin core, this is potentially hazardous to a core update in which a patch provided by lightning may no longer apply.

PR enables exiting composer when a patch fails to apply.