### PR TITLE
Remove .travis.yml after creating new project.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ install:
 
   # Build the Lightning code base.
   - composer install
+  - composer require --dev acquia/lightning_dev:dev-8.x-1.x
 
   # Install Lightning.
   - DB_URL='mysql\://lightning:lightning@127.0.0.1/drupal'

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "scripts": {
         "post-install-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "post-update-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+        "post-create-project-cmd": "rm .travis.yml",
         "nuke": "rm -r -f docroot/modules/contrib docroot/profiles/contrib/lightning vendor composer.lock",
         "quick-start": [
             "composer install",

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
     "prefer-stable": true,
     "require-dev": {
         "drush/drush": "^9.0",
-        "drupal/media_entity_generic": "^1.0",
-        "acquia/lightning_dev": "dev-8.x-1.x"
+        "drupal/media_entity_generic": "^1.0"
     },
     "require": {
         "drupal-composer/drupal-scaffold": "^2.0.0",
@@ -36,7 +35,7 @@
     "scripts": {
         "post-install-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "post-update-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
-        "post-create-project-cmd": "rm .travis.yml && composer remove --dev acquia/lightning_dev",
+        "post-create-project-cmd": "rm .travis.yml",
         "nuke": "rm -r -f docroot/modules/contrib docroot/profiles/contrib/lightning vendor composer.lock",
         "quick-start": [
             "composer install",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "scripts": {
         "post-install-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "post-update-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
-        "post-create-project-cmd": "rm .travis.yml",
+        "post-create-project-cmd": "rm .travis.yml && composer remove --dev acquia/lightning_dev",
         "nuke": "rm -r -f docroot/modules/contrib docroot/profiles/contrib/lightning vendor composer.lock",
         "quick-start": [
             "composer install",


### PR DESCRIPTION
Currently when you create a new project, you get a copy of lightning-project's .travis.yml. That seems like unneeded cruft for downstream projects. This removes .travis.yml after a project is initially created.