### PR TITLE
Stop testing PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
     - "$HOME/.drush/cache"
     - "$HOME/.npm"
 php:
-  - 7.0
   - 7.1
 
 env:


### PR DESCRIPTION
PHP 7.0 has the same EOL date as PHP 5.6, aka pretty close to now. I've never seen a functional difference between 7.0 and 7.1 cause tests to fail. And I'd like to de-congest our test infrastructure, some tests queue for hours right now.

Taken together, I think these are pretty strong arguments for dropping testing of PHP 7.0. Let me know what you think.