### PR TITLE
Ensure Drupal's require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "drupal-composer/drupal-scaffold": "^2.0.0"
     },
     "require-dev": {
-        "drush/drush": "^9.0"
+        "drush/drush": "^9.0",
+        "webflo/drupal-core-require-dev": "^8.7.0"
     },
     "config": {
         "process-timeout": 0


### PR DESCRIPTION
I discovered during some `drupal-check` tests this template _does not_ install Drupal's dev dependencies. That means PHPUnit isn't available or other things required for running Drupal's test suite from this template.

```
composer create-project acquia/lightning-project /tmp/drupal --no-interaction --prefer-dist --ignore-platform-reqs
Installing acquia/lightning-project (8.7.0)
  - Installing acquia/lightning-project (8.7.0): Downloading (100%)
```

The only dev is

```
- Installing drush/drush (9.6.2): Loading from cache
```