### PR TITLE
Default to 4.x branch of Lightning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 
   # Add dev dependencies that shouldn't be shipped to implementors and build the
   # Lightning code base.
-  - composer require --dev acquia/lightning_dev:dev-8.x-1.x drupal/media_entity_generic:^1.0 --no-update
+  - composer require --dev acquia/lightning_dev:dev-8.x-1.x drupal/media_entity_generic:^1.0 drupal/lightning_layout:2.0.0 --no-update
   - composer install
 
   # Install Lightning.

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   # Lightning code base.
   - composer require --dev acquia/lightning_dev:dev-8.x-1.x drupal/media_entity_generic:^1.0 --no-update
   - composer install
-  - composer info drupal/lighting_layout
+  - composer info drupal/lightning_layout
   - composer why-not drupal/lightning_layout:2.0.0
 
   # Install Lightning.

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,9 @@ install:
   # Add dev dependencies that shouldn't be shipped to implementors and build the
   # Lightning code base.
   - composer require --dev acquia/lightning_dev:dev-8.x-1.x drupal/media_entity_generic:^1.0 --no-update
-  - composer install --dry-run
   - composer install
+  - composer info drupal/lighting_layout
+  - composer why-not drupal/lightning_layout:2.0.0
 
   # Install Lightning.
   - lightning install $DB_URL lightning $HOST

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ install:
   # Lightning code base.
   - composer require --dev acquia/lightning_dev:dev-8.x-1.x drupal/media_entity_generic:^1.0 --no-update
   - composer install
-  - composer info drupal/lightning_layout
-  - composer why-not drupal/lightning_layout:2.0.0
 
   # Install Lightning.
   - lightning install $DB_URL lightning $HOST

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ install:
   # Add dev dependencies that shouldn't be shipped to implementors and build the
   # Lightning code base.
   - composer require --dev acquia/lightning_dev:dev-8.x-1.x drupal/media_entity_generic:^1.0 --no-update
+  - composer install --dry-run
   - composer install
 
   # Install Lightning.

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 
   # Add dev dependencies that shouldn't be shipped to implementors and build the
   # Lightning code base.
-  - composer require --dev acquia/lightning_dev:dev-8.x-1.x drupal/media_entity_generic:^1.0 drupal/lightning_layout:2.0.0 --no-update
+  - composer require --dev acquia/lightning_dev:dev-8.x-1.x drupal/media_entity_generic:^1.0 --no-update
   - composer install
 
   # Install Lightning.

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 
   # Update code base to HEAD.
   - composer nuke
-  - composer require acquia/lightning:dev-8.x-3.x --no-update
+  - composer require acquia/lightning:dev-8.x-4.x --no-update
   - composer update
 
   # Run database and Lightning config updates.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "process-timeout": 0
     },
     "extra": {
-        "composer-exit-on-patch-failure": false,
+        "composer-exit-on-patch-failure": true,
         "enable-patching": true,
         "installer-paths": {
             "docroot/core": [

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Project template for Drupal 8 sites built with the Lightning distribution.",
     "license": "GPL-2.0-or-later",
     "require": {
-        "acquia/lightning": "~3.3.0",
+        "acquia/lightning": "^4.0",
         "cweagans/composer-patches": "^1.6.0",
         "drupal-composer/drupal-scaffold": "^2.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "process-timeout": 0
     },
     "extra": {
-        "composer-exit-on-patch-failure": true,
+        "composer-exit-on-patch-failure": false,
         "enable-patching": true,
         "installer-paths": {
             "docroot/core": [


### PR DESCRIPTION
This PR switches the constraint on Lightning from ~3.3.0 to ^4.0. The looser constraint will allow people to update between minor versions (of Lightning and Drupal core) without changing their own constraint.