### PR TITLE
Switch from drupal-composer/drupal-scaffold to drupal/core-composer-scaffold

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ install:
   - rm composer.lock
   # Update code base to HEAD.
   - composer require acquia/lightning:dev-8.x-4.x --no-update
+  # Workaround until Issue #3091285 is resolved.
+  - chmod -R +w docroot/sites/default
   - composer update
 
   # Run database and Lightning config updates.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "acquia/lightning": "^4.0",
         "cweagans/composer-patches": "^1.6.0",
-        "drupal-composer/drupal-scaffold": "^2.0.0"
+        "drupal/core-composer-scaffold": "*"
     },
     "require-dev": {
         "drush/drush": "^9.0"
@@ -16,6 +16,11 @@
     },
     "extra": {
         "composer-exit-on-patch-failure": true,
+        "drupal-scaffold": {
+            "locations": {
+                "web-root": "docroot/"
+            }
+        },
         "enable-patching": true,
         "installer-paths": {
             "docroot/core": [
@@ -57,8 +62,6 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "post-install-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
-        "post-update-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "post-create-project-cmd": "rm -r -f .travis.yml behat.yml .travis-ci",
         "quick-start": [
             "composer install",


### PR DESCRIPTION
`drupal-composer/drupal-scaffold` has been deprecated in favor of `drupal/core-composer-scaffold`. This PR replaces the old with the new.

Since the Travis CI config triggers the scaffold plugin twice (once during the first install, then again on an update) it hits [Issue #3091285](https://www.drupal.org/project/drupal/issues/3091285). Line 50 of `.travis.yml` works around that bug.